### PR TITLE
SPI Preparation

### DIFF
--- a/.spi.yml
+++ b/.spi.yml
@@ -1,0 +1,4 @@
+version: 1
+builder:
+  configs:
+    - documentation_targets: [EmailSender, PersPersistenceistence]

--- a/Package.swift
+++ b/Package.swift
@@ -11,7 +11,7 @@ let package = Package(
         .library(name: "Persistence", targets: ["Persistence"])
     ],
     dependencies: [
-        .package(url: "https://github.com/awslabs/aws-sdk-swift", from: "0.19.0")
+        .package(url: "https://github.com/awslabs/aws-sdk-swift.git", from: "0.19.0")
     ],
     targets: [
         .target(


### PR DESCRIPTION
SPI requires that dependencies include the `.git` extension; this fixes that and adds a manifest file.