### PR TITLE
Update Persistence with attributeModifier Member

### DIFF
--- a/Sources/Persistence/Persistence.swift
+++ b/Sources/Persistence/Persistence.swift
@@ -46,6 +46,24 @@ public struct Persistence {
     }
 }
 
+public extension Persistence {
+    /// Returns an instance that adds a `CreatedAt` timestamp from the given `TimeStampProvider` to
+    /// all persisted entities.
+    ///
+    /// - Parameters:
+    ///   - timestampProvider: A timestamp provider.
+    ///   - put: A closure to persist item attributes.
+    /// - Returns: A `Persistence` instance.
+    static func addingTimestamp(
+        from timestampProvider: TimestampProvider,
+        put: @escaping @Sendable ([String: AttributeValue]) async throws -> Void
+    ) -> Self {
+        .init(
+            put: put,
+            attributeModifier: { $0.merging(["CreatedAt": .s(timestampProvider.timestamp())]) { _, new in new } })
+    }
+}
+
 /// A type that creates ``Persistence`` instances.
 public struct PersistenceFactory {
     /// The region where the table is located.

--- a/Sources/Persistence/Persistence.swift
+++ b/Sources/Persistence/Persistence.swift
@@ -51,16 +51,18 @@ public extension Persistence {
     /// all persisted entities.
     ///
     /// - Parameters:
+    ///   - timestampName: The name of the timestamp attribute.
     ///   - timestampProvider: A timestamp provider.
     ///   - put: A closure to persist item attributes.
     /// - Returns: A `Persistence` instance.
     static func addingTimestamp(
+        named timestampName: String,
         from timestampProvider: TimestampProvider,
         put: @escaping @Sendable ([String: AttributeValue]) async throws -> Void
     ) -> Self {
         .init(
             put: put,
-            attributeModifier: { $0.merging(["CreatedAt": .s(timestampProvider.timestamp())]) { _, new in new } })
+            attributeModifier: { $0.merging([timestampName: .s(timestampProvider.timestamp())]) { _, new in new } })
     }
 }
 

--- a/Tests/PersistenceTests/PersistenceTests.swift
+++ b/Tests/PersistenceTests/PersistenceTests.swift
@@ -16,14 +16,15 @@ final class PersistenceTests: XCTestCase {
         let string: String
 
         var attributes: [String: AttributeValue] {
-            var values: [CodingKeys: AttributeValue] = [
+            let values: [CodingKeys: AttributeValue] = [
                 .bool: .bool(bool),
                 .string: .s(string)
             ]
-
             return values.attributeValues()
         }
     }
+
+    let timeoutInterval: TimeInterval =  0.1
 
     func testPersistence() async throws {
         let expected: [String: AttributeValue] = [
@@ -43,6 +44,6 @@ final class PersistenceTests: XCTestCase {
         }
 
         try await sut.put(Model(bool: true, string: "string"))
-        await fulfillment(of: [expectation])
+        await fulfillment(of: [expectation], timeout: timeoutInterval)
     }
 }

--- a/Tests/PersistenceTests/PersistenceTests.swift
+++ b/Tests/PersistenceTests/PersistenceTests.swift
@@ -37,7 +37,7 @@ final class PersistenceTests: XCTestCase {
             formatter: ISO8601DateFormatter())
 
         let expectation = expectation(description: "Model persisted")
-        let sut = Persistence.addingTimestamp(from: timestampProvider) { actual in
+        let sut = Persistence.addingTimestamp(named: "CreatedAt", from: timestampProvider) { actual in
             XCTAssertEqual(actual, expected)
             expectation.fulfill()
         }


### PR DESCRIPTION
Previously, the live implementation of `PersistenceFactory` was created with a closure to support adding extra attributes (like a timestamp) to persisted values. This made it difficult to test that those values were actually added since the attribute addition was coupled with the use of DynamoDB to persist entities.

This fixes that by moving that closure to `Persistence` so that it can be tested independently of the logic used to actually persist values (via the `put` attribute) and revisions it more generally as a closure to modify persisted values. It also adds a member to create a `Persistence` instance that adds a timestamp to all persisted entities and a test for it.